### PR TITLE
nix: add cachix CI

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,22 @@
+name: "Build and Deploy to Cachix"
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0 # Nix Flakes doesn't work on shallow clones
+    - uses: cachix/install-nix-action@v16
+      with:
+        extra_nix_config: |
+              experimental-features = nix-command flakes
+              extra-substituters = https://contamination.cachix.org
+              extra-trusted-public-keys = contamination.cachix.org-1:KmdW5xVF8ccKEb9tvK6qtEMW+lGa83seGgFyBOkeM/4
+    - uses: cachix/cachix-action@v10
+      with:
+        name: contamination
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix build

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,9 @@
 {
   description = "A very minimal flake for building and running contamination";
 
+  nixConfig.extra-substituters = [ "https://contamination.cachix.org" ];
+  nixConfig.extra-trusted-public-keys = [ "contamination.cachix.org-1:KmdW5xVF8ccKEb9tvK6qtEMW+lGa83seGgFyBOkeM/4=" ];
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
Added a GitHub workflow that builds the Nix flake then deploys the build artifacts to the dedicated Cachix binary cache.

Over-engineering is fun. 